### PR TITLE
Fix expand_make_variables replacements and usage

### DIFF
--- a/cuda/defs.bzl
+++ b/cuda/defs.bzl
@@ -133,7 +133,7 @@ def _cuda_library_impl(ctx):
                 action_name = CUDA_ACTION_NAMES.compile,
                 feature_configuration = cuda_features,
                 variables = cuda_compile_variables,
-            ) + [expand_make_variables(opt) for opt in ctx.attr.dcopts]
+            ) + [expand_make_variables(ctx, opt) for opt in ctx.attr.dcopts]
         )
         ctx.actions.run(
             executable = nvcc_path,
@@ -173,7 +173,7 @@ def _cuda_library_impl(ctx):
                 action_name = CUDA_ACTION_NAMES.link,
                 feature_configuration = cuda_features,
                 variables = cuda_link_variables,
-            ) + [expand_make_variables(opt) for opt in ctx.attr.dlinkopts]
+            ) + [expand_make_variables(ctx, opt) for opt in ctx.attr.dlinkopts]
         )
         ctx.actions.run(
             executable = nvcc_path,

--- a/cuda/private/rules/utils.bzl
+++ b/cuda/private/rules/utils.bzl
@@ -239,6 +239,6 @@ def combine_env(ctx, host_env, device_env):
     return env
 
 def expand_make_variables(ctx, value):
-    for key, value in ctx.var.items():
-        value = value.replace('$({})'.format(key), value)
+    for k, v in ctx.var.items():
+        value = value.replace('$({})'.format(k), v)
     return value


### PR DESCRIPTION
The `value` variable was shadowed, so it always replaced dcopts with the last var's value instead of the input.